### PR TITLE
Changed return value of 'MpgToKPM' method in RomanVytrykush/EightImpl

### DIFF
--- a/src/main/java/com/org/ita/kata/implementation/RomanVytrykush/EightImpl.java
+++ b/src/main/java/com/org/ita/kata/implementation/RomanVytrykush/EightImpl.java
@@ -20,7 +20,7 @@ public class EightImpl implements Eight {
         float x = gallonToLitres;
         float y = mileToKilometer;
 
-        return Float.parseFloat(String.format("%.2f", mpg * y / x ));
+        return mpg * y / x ;
     }
 
     @Override


### PR DESCRIPTION
changed 'return Float.parseFloat(String.format("%.2f", mpg * y / x ));' to 'return mpg * y / x ;' to suit new code.